### PR TITLE
Support query when neo4 return the actual number instead of a object.

### DIFF
--- a/lib/service/neo4j.model.service.ts
+++ b/lib/service/neo4j.model.service.ts
@@ -43,7 +43,7 @@ export abstract class Neo4jModelService<T> {
    */
   public fromNeo4j(record: Record<string, any>): T {
     let result: Record<string, any> = { ...record };
-    if (this.timestamp && record && record[this.timestamp]) {
+    if (this.timestamp && typeof result[this.timestamp] !== "number" && record && record[this.timestamp]) {
       result[this.timestamp] = new Date(result[this.timestamp].toNumber());
     }
     return result as T;


### PR DESCRIPTION
This PR adds just a small check when the retured value from the neo4J is actually a number.
This situation happens when dev sets `disableLosslessIntegers:true` options in the driver configurations [https://www.npmjs.com/package/neo4j-driver](url)

Hope this PR gets merged ASAP :hand: 